### PR TITLE
Feat/create make move helper functions

### DIFF
--- a/managers/bitboard_manager.py
+++ b/managers/bitboard_manager.py
@@ -29,6 +29,13 @@ class BitboardManager:
         self.preserved_enpassant = self.enpassant
         self.preserved_castle = self.castle
 
+    def set_attributes(self):
+        self.bitboards = list(self.preserved_bitboards)
+        self.occupancies = list(self.preserved_occupancies)
+        self.side = self.preserved_side
+        self.enpassant = self.preserved_enpassant
+        self.castle = self.preserved_castle
+
     def parse_fen(self, fen):
         parser = FenParser(self)
         parser.parse(fen)

--- a/managers/bitboard_manager.py
+++ b/managers/bitboard_manager.py
@@ -1,3 +1,5 @@
+import copy
+
 from src.utilities.bit import Bit
 from src.utilities.console import Console
 
@@ -19,6 +21,13 @@ class BitboardManager:
         self.side = 0
         self.enpassant = SQUARES["null"]
         self.castle = 0
+
+    def preserve_attributes(self):
+        self.preserved_bitboards = list(self.bitboards)
+        self.preserved_occupancies = list(self.occupancies)
+        self.preserved_side = self.side
+        self.preserved_enpassant = self.enpassant
+        self.preserved_castle = self.castle
 
     def parse_fen(self, fen):
         parser = FenParser(self)

--- a/src/app/app.py
+++ b/src/app/app.py
@@ -30,12 +30,15 @@ class App:
         self.bitboard_manager = BitboardManager(self)
 
         self.bitboard_manager.parse_fen(
-            "r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1 "
+            "r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq c6 0 1 "
         )
         self.bitboard_manager.print_board()
 
-        move_generator = MoveGenerator(self)
-        moves = move_generator.get_moves()
-        # moves = Move.get_moves(self)
+        self.bitboard_manager.preserve_attributes()
 
-        Console.print_moves(moves)
+        self.bitboard_manager.parse_fen(EMPTY_BOARD)
+        self.bitboard_manager.print_board()
+
+        self.bitboard_manager.set_attributes()
+
+        self.bitboard_manager.print_board()

--- a/tests/temp.py
+++ b/tests/temp.py
@@ -1,20 +1,21 @@
 class A:
     def __init__(self):
-        self.a = []
+        self.a = [1, 2, 4]
+        self.b = 1
+        self.c = self.b
 
+        self.b += 1
 
-class B:
-    def __init__(self, a):
-        self.a = a
-        self.b = self.a.a
+        print(self.c)
+
+    def get_list(self):
+        return [a for a in self.a]
 
 
 foo = A()
-bar = B(foo)
-car = B(foo)
 
 print(foo.a)
+b = foo.get_list()
+b.append(3)
 
-foo.a.append(1)
-
-print(bar.b)
+print(foo.a, b)


### PR DESCRIPTION
# Description
- Resolves #55 
- Implemented helper functions before implementing the `make move` function.
- There are two helper functions:
  - `preserve_attributes()`:
    - Preserves the bitboard manager's attributes.
  - `set_attributes()`:
    - Sets the current bitboard manager attributes to the preserved board attributes.